### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/AgentToolkit/examples/tutorial/README.md
+++ b/AgentToolkit/examples/tutorial/README.md
@@ -21,7 +21,7 @@ Currently, the supported commands are:
         To move east/west increase or decrease the x coordinate respectively.
         To move south/north increase or decrease the z coordinate respectively.
         To move up/down increase or decrease the y coordinate respectively.
-        See https://minecraft.fandom.com/wiki/Coordinates#World_coordinates
+        See https://minecraft.wiki/w/Coordinates#World_coordinates
     look:<[up|down]> moves pitch by 45 degrees on the desired direction.
         Looking stratight up corresponds to pitch -90, and straigh down to pitch 90.
 

--- a/AgentToolkit/examples/tutorial/agents/command_agent.py
+++ b/AgentToolkit/examples/tutorial/agents/command_agent.py
@@ -27,7 +27,7 @@ class ChatCommandAgent(Agent):
             To move east/west increase or decrease the x coordinate respectively.
             To move south/north increase or decrease the z coordinate respectively.
             To move up/down increase or decrease the y coordinate respectively.
-            See https://minecraft.fandom.com/wiki/Coordinates#World_coordinates
+            See https://minecraft.wiki/w/Coordinates#World_coordinates
         look:<[up|down]> moves pitch by 45 degrees on the desired direction.
             Looking stratight up corresponds to pitch -90, and straigh down to pitch 90.
         exit: leave the game.
@@ -123,7 +123,7 @@ class ChatCommandAgent(Agent):
 
         # X - (+) east (-) west
         # Z - (-) north (+) south
-        # https://minecraft.fandom.com/wiki/Coordinates#World_coordinates
+        # https://minecraft.wiki/w/Coordinates#World_coordinates
         if "north" in self.current_command:
             # Decrease in Z is movement in northern direction
             move_action.z -= self.position_movement_distance
@@ -152,7 +152,7 @@ class ChatCommandAgent(Agent):
 
     def handle_look(self, current_agent_position):
         # For the vertical rotation (pitch), -90.0 for straight up to 90.0 for straight down.
-        # https://minecraft.fandom.com/wiki/Commands/tp/Before_Java_Edition_17w45a
+        # https://minecraft.wiki/w/Commands/tp/Before_Java_Edition_17w45a
         new_pitch = current_agent_position['pitch']
         if 'down' in self.current_command:
             new_pitch = max(current_agent_position['pitch'] + 45.0, 90.0)
@@ -191,7 +191,7 @@ class ChatCommandAgent(Agent):
         # For horizontal rotation (yaw), -180.0 for due north, -90.0 for due east,
         # 0.0 for due south, 90.0 for due west, to 179.9 for just west of due north,
         # before wrapping back around to -180.0.
-        # https://minecraft.fandom.com/wiki/Commands/tp/Before_Java_Edition_17w45a
+        # https://minecraft.wiki/w/Commands/tp/Before_Java_Edition_17w45a
         new_yaw = current_agent_position['yaw']
         if direction == 'right':
             new_yaw += degrees

--- a/McPlugin/Common/src/main/java/com/microsoft/greenlands/common/utils/BlockUtils.java
+++ b/McPlugin/Common/src/main/java/com/microsoft/greenlands/common/utils/BlockUtils.java
@@ -215,7 +215,7 @@ public class BlockUtils {
     var maxChunkX = CommonConstants.WORLD_MIN_CHUNK_SIZE;
     var maxChunkZ = CommonConstants.WORLD_MIN_CHUNK_SIZE;
     // Chunk Height documentation
-    // https://minecraft.fandom.com/wiki/Java_Edition_1.18_Experimental_Snapshot_1#General
+    // https://minecraft.wiki/w/Java_Edition_1.18_Experimental_Snapshot_1#General
     var minChunkY = -64;
     var maxChunkY = 320;
 

--- a/McPlugin/Common/src/main/java/com/microsoft/greenlands/common/utils/WorldUtils.java
+++ b/McPlugin/Common/src/main/java/com/microsoft/greenlands/common/utils/WorldUtils.java
@@ -237,7 +237,7 @@ public class WorldUtils {
    * A Chunk is a column of size 16(x) * 16(z) * 384(y), 98,304 blocks total. They extend from Y=-64
    * to Y=320.
    *
-   * https://minecraft.fandom.com/wiki/Chunk
+   * https://minecraft.wiki/w/Chunk
    */
   public static void loadChunksAroundLocation(
       World world,

--- a/McPlugin/Plugins/GameServerPlugin/src/main/java/com/microsoft/greenlands/gameserver/entities/ActiveGameState.java
+++ b/McPlugin/Plugins/GameServerPlugin/src/main/java/com/microsoft/greenlands/gameserver/entities/ActiveGameState.java
@@ -394,7 +394,7 @@ public class ActiveGameState {
     // use this workaround to get the confirmation code in the user's text-box,
     // from where they are able to copy it For more information on the `tellraw`
     // command check out:
-    // https://minecraft.fandom.com/wiki/Commands/tellraw
+    // https://minecraft.wiki/w/Commands/tellraw
 
     ServerUtils.tellRawToPlayer(player.getName(), Map.of(
         "text", "\n>> Click here to get your confirmation code!\n",


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki